### PR TITLE
fix(deps): allow studio v4 in peer dep ranges + update main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,11 +105,20 @@ jobs:
     runs-on: ubuntu-latest
     name: Semantic release
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.ECOSPARK_APP_ID }}
+          private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
           # Need to fetch entire commit history to
           # analyze every commit since last release
           fetch-depth: 0
+          # Uses generated token to allow pushing commits back
+          token: ${{ steps.app-token.outputs.token }}
+          # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           cache: npm
@@ -118,9 +127,6 @@ jobs:
       - run: npm audit signatures
         # Branches that will release new versions are defined in .releaserc.json
       - run: npx semantic-release
-        # Don't allow interrupting the release step if the job is cancelled, as it can lead to an inconsistent state
-        # e.g. git tags were pushed but it exited before `npm publish`
-        if: always()
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@sanity/embeddings-cli",
+  "name": "@sanity/embeddings-index-cli",
   "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@sanity/embeddings-cli",
+      "name": "@sanity/embeddings-index-cli",
       "version": "1.0.10",
       "license": "MIT",
       "dependencies": {
@@ -17,7 +17,7 @@
         "zod": "^3.22.1"
       },
       "bin": {
-        "embeddings": "bin/embeddings-index.js"
+        "embeddings-index": "bin/embeddings-index.js"
       },
       "devDependencies": {
         "@commitlint/cli": "^17.7.1",
@@ -45,7 +45,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "sanity": "^3.11.0"
+        "sanity": "^3.11.0 || ^4.0.0-0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "typescript": "^5.1.6"
   },
   "peerDependencies": {
-    "sanity": "^3.11.0"
+    "sanity": "^3.11.0 || ^4.0.0-0"
   },
   "engines": {
     "node": ">=14"


### PR DESCRIPTION
### Description

Prepping for July 15th: https://www.sanity.io/blog/a-major-version-bump-for-a-minor-reason#299526b398ec

Currently when using a package.json like: 
```
Progress: resolved 1038, reused 0, downloaded 0, added 0, done
 WARN  Issues with peer dependencies found
.
└─┬ @sanity/embeddings-index-cli 1.0.10
  └── ✕ unmet peer sanity@^3.11.0: found 4.0.0-0
Done in 7.4s using pnpm v10.12.1
```
This fixes it.

### Testing

Tested locally