### PR TITLE
fix(deps): allow studio v5 in peer deps ranges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "sanity": "^3.11.0 || ^4.0.0-0"
+        "sanity": "^3.11.0 || ^4.0.0-0 || ^5.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "typescript": "^5.1.6"
   },
   "peerDependencies": {
-    "sanity": "^3.11.0 || ^4.0.0-0"
+    "sanity": "^3.11.0 || ^4.0.0-0 || ^5.0.0"
   },
   "engines": {
     "node": ">=14"


### PR DESCRIPTION
### Description
This pull request updates the peer dependencies to support Sanity version 5.x, allowing the plugin to work with the latest major version of Sanity Studio while maintaining backward compatibility with versions 3.x and 4.x.